### PR TITLE
Add CSV upload interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # yapay_zeka
+
 yapay zeka
 llm model fine tune uygulaması
+
+## CSV Yükleme Arayüzü
+
+`load_csv.py` dosyası, yerel diskinizden CSV dosyası seçmeniz için basit bir Tkinter arayüzü sağlar. 
+
+Çalıştırmak için:
+
+```bash
+python load_csv.py
+```
+
+Açılan pencereden `CSV Dosyası Yükle` butonuna basarak dosyayı seçebilirsiniz. Seçilen dosya yolu ve ilk satırları ekranda görüntülenir.

--- a/load_csv.py
+++ b/load_csv.py
@@ -1,0 +1,36 @@
+import csv
+import tkinter as tk
+from tkinter import filedialog
+
+def load_csv():
+    file_path = filedialog.askopenfilename(
+        title="CSV Seç",
+        filetypes=[("CSV files", "*.csv")]
+    )
+    if file_path:
+        with open(file_path, newline='', encoding='utf-8') as csvfile:
+            reader = csv.reader(csvfile)
+            preview_lines = []
+            for i, row in enumerate(reader):
+                preview_lines.append(", ".join(row))
+                if i == 4:
+                    break
+            preview = "\n".join(preview_lines)
+        text.config(state=tk.NORMAL)
+        text.delete(1.0, tk.END)
+        text.insert(tk.END, f"Se\u00e7ilen dosya: {file_path}\n\u00d6n izleme:\n{preview}")
+        text.config(state=tk.DISABLED)
+
+root = tk.Tk()
+root.title("CSV Y\u00fckleyici")
+
+frame = tk.Frame(root)
+frame.pack(padx=20, pady=20)
+
+button = tk.Button(frame, text="CSV Dosyas\u0131 Y\u00fckle", command=load_csv)
+button.pack()
+
+text = tk.Text(frame, width=60, height=10, state=tk.DISABLED)
+text.pack(pady=(10, 0))
+
+root.mainloop()


### PR DESCRIPTION
## Summary
- add a `load_csv.py` Tkinter interface to select a CSV file locally and show a preview
- update README with usage instructions

## Testing
- `python -m py_compile load_csv.py`


------
https://chatgpt.com/codex/tasks/task_e_68628de0a8b48332ba240cf545a3562a